### PR TITLE
Fixed spelling of 'quadradic' and added feature to alg input

### DIFF
--- a/src/edu/allegheny/expose/BigOh.java
+++ b/src/edu/allegheny/expose/BigOh.java
@@ -27,7 +27,7 @@ public class BigOh{
 
             this.compClass = compClass;
 
-            if (compClass == ComplexityClass.QUADRADIC)
+            if (compClass == ComplexityClass.QUADRATIC)    // changed "QUADRADIC"to "QUADRATIC"
                 exponent = 2;
             else if (compClass == ComplexityClass.CUBIC)
                 exponent = 3;
@@ -70,7 +70,7 @@ public class BigOh{
         else
             return compClass.toString();
     }
-    
+
     public boolean equals(BigOh o){
         if (o.compClass == this.compClass && o.exponent == this.exponent){
             return true;
@@ -80,5 +80,3 @@ public class BigOh{
     }
 
 }
-
-

--- a/src/edu/allegheny/expose/ComplexityClass.java
+++ b/src/edu/allegheny/expose/ComplexityClass.java
@@ -6,7 +6,7 @@ public enum ComplexityClass{
     LOGARITHMIC,
     LINEAR,
     LINEARITHMIC,
-    QUADRADIC,
+    QUADRATIC,    // changed "QUADRADIC"to "QUADRATIC"
     CUBIC,
     POWER,
     EXPONENTIAL;

--- a/src/edu/allegheny/expose/ReverseEngineer.java
+++ b/src/edu/allegheny/expose/ReverseEngineer.java
@@ -14,14 +14,14 @@ public class ReverseEngineer{
      * It will have already been sorted by times doubled
      */
     private ExperimentResults data;
-    
+
     /**
      * Data aggregated by times doubled
      */
     private List<Double[]> avg;
 
     /**
-     * Percentage that min / max of a dataset must be within to be considered 
+     * Percentage that min / max of a dataset must be within to be considered
      * consistant
      */
     private static double spreadTolerance = .10;
@@ -75,7 +75,7 @@ public class ReverseEngineer{
         data.readCSV(fileName);
     }
 
-   
+
     /**
      * Analyze the results of a doubling experiment.
      * @return BigOh determined from data
@@ -105,7 +105,7 @@ public class ReverseEngineer{
 
         BigOh result = new BigOh();
 
-        // now in the case of N^0 or N^1, get more specific 
+        // now in the case of N^0 or N^1, get more specific
         if ( exp == 0 ){
             // check for constant time
             if (checkConstant()){
@@ -120,7 +120,7 @@ public class ReverseEngineer{
                 result.setCompClass(ComplexityClass.LINEARITHMIC);
             }
         }else if (exp == 2){
-                result.setCompClass(ComplexityClass.QUADRADIC);
+                result.setCompClass(ComplexityClass.QUADRATIC);    // changed "QUADRADIC"to "QUADRATIC"
         }else if (exp == 3){
             result.setCompClass(ComplexityClass.CUBIC);
         }else{
@@ -167,7 +167,7 @@ public class ReverseEngineer{
      * @return true if the data is deemed O(n)
      */
     protected boolean checkConstant(){
-    
+
         aggregate();
 
         // fetch last 3 elements
@@ -182,7 +182,7 @@ public class ReverseEngineer{
      * @return true if the data is deemed O(nlog(n))
      */
     protected boolean checkLinear(){
-    
+
         aggregate();
 
         // fetch last 3 elements
@@ -191,13 +191,13 @@ public class ReverseEngineer{
         // divide by n
         double[] div = {last[0] / 4, last[1] / 2, last[2] };
 
-        // check to see that these values are within tolerance of each other 
+        // check to see that these values are within tolerance of each other
         return checkWithinRange(div, spreadTolerance);
 
     }
-    
-    
-    
 
-    
+
+
+
+
 }

--- a/src/edu/allegheny/expose/ReverseEngineerTest.java
+++ b/src/edu/allegheny/expose/ReverseEngineerTest.java
@@ -15,7 +15,7 @@ public class ReverseEngineerTest{
         eng.loadData("tests/bubblesort.csv");
         BigOh res = eng.analyzeData();
         ComplexityClass ans = res.getCompClass();
-        Assert.assertEquals(ans, ComplexityClass.QUADRADIC);
+        Assert.assertEquals(ans, ComplexityClass.QUADRATIC);    // changed "QUADRADIC"to "QUADRATIC"
     }
 
 
@@ -55,5 +55,5 @@ public class ReverseEngineerTest{
         Assert.assertEquals(ans, ComplexityClass.LINEAR);
     }
 
-    
+
 }

--- a/src/edu/allegheny/expose/examples/sort/SortingExperiment.java
+++ b/src/edu/allegheny/expose/examples/sort/SortingExperiment.java
@@ -12,7 +12,6 @@ public class SortingExperiment extends DoublingExperiment{
     protected int alg;
     protected String name;
     private int[] n;
-    private static boolean validAlg;    // to check validity of algorithm name input
 
     public static String[] algs = {"quick", "insertion", "merge", "selection", "bubble"};
 
@@ -26,7 +25,7 @@ public class SortingExperiment extends DoublingExperiment{
         SortingExperiment exp = new SortingExperiment(nargs);
         exp.name = args[0];
 
-        validAlg = false;    // input assumed to be invalid algorithm
+        boolean validAlg = false;    // input assumed to be invalid algorithm
         for (int i = 0; i < algs.length; i++) {    // for each valid algorithm option...
           if (algs[i].equals(exp.name)) {    // check if input equals valid algorithm option
             validAlg = true;    // true when input matches at least one valid algorithm
@@ -34,6 +33,7 @@ public class SortingExperiment extends DoublingExperiment{
         }
         if (!validAlg) {    // if input is invalid...
           System.out.println("Sorry, that is not a valid \"Sorting\" algorithm.");
+          System.out.println("Supported algorithms are: " + Arrays.toString(algs));
           return;    // exit main method
         }
 

--- a/src/edu/allegheny/expose/examples/sort/SortingExperiment.java
+++ b/src/edu/allegheny/expose/examples/sort/SortingExperiment.java
@@ -12,6 +12,7 @@ public class SortingExperiment extends DoublingExperiment{
     protected int alg;
     protected String name;
     private int[] n;
+    private static boolean validAlg;    // to check validity of algorithm name input
 
     public static String[] algs = {"quick", "insertion", "merge", "selection", "bubble"};
 
@@ -24,6 +25,17 @@ public class SortingExperiment extends DoublingExperiment{
 
         SortingExperiment exp = new SortingExperiment(nargs);
         exp.name = args[0];
+
+        validAlg = false;    // input assumed to be invalid algorithm
+        for (int i = 0; i < algs.length; i++) {    // for each valid algorithm option...
+          if (algs[i].equals(exp.name)) {    // check if input equals valid algorithm option
+            validAlg = true;    // true when input matches at least one valid algorithm
+          }
+        }
+        if (!validAlg) {    // if input is invalid...
+          System.out.println("Sorry, that is not a valid \"Sorting\" algorithm.");
+          return;    // exit main method
+        }
 
         switch (exp.name){
             case "quick":

--- a/src/edu/allegheny/expose/examples/sort/SortingExperimentRepeated.java
+++ b/src/edu/allegheny/expose/examples/sort/SortingExperimentRepeated.java
@@ -7,17 +7,17 @@ import edu.allegheny.expose.ComplexityClass;
 
 public class SortingExperimentRepeated{
 
-    private static final BigOh quadratic = new BigOh(ComplexityClass.QUADRADIC);
+    private static final BigOh quadratic = new BigOh(ComplexityClass.QUADRATIC);    // changed "QUADRADIC"to "QUADRATIC"
     private static final BigOh linearithmic = new BigOh(ComplexityClass.LINEARITHMIC);
 
 
    public static void main(String[] args){
-       
+
        int experiments = 0;
        int correct = 0;
 
        for (int count = 0; count < Integer.parseInt(args[0]); count++){
-       
+
 
       for (String a : SortingExperiment.algs) {
           BigOh ans = SortingExperiment.doubleExp(a);

--- a/src/edu/allegheny/expose/examples/unique/UniqueExperiment.java
+++ b/src/edu/allegheny/expose/examples/unique/UniqueExperiment.java
@@ -12,6 +12,7 @@ public class UniqueExperiment extends DoublingExperiment {
   protected int alg;
   protected String name;
   private int[] n;
+  private static boolean validAlg;    // to check validity of algorithm name input
 
   public static String[] algs = {"unique1", "unique2"};
 
@@ -25,6 +26,17 @@ public class UniqueExperiment extends DoublingExperiment {
 
     UniqueExperiment exp = new UniqueExperiment(nargs);
     exp.name = args[0];
+
+    validAlg = false;    // input assumed to be invalid algorithm
+    for (int i = 0; i < algs.length; i++) {    // for each valid algorithm option...
+      if (algs[i].equals(exp.name)) {    // check if input equals valid algorithm option
+        validAlg = true;    // true when input matches at least one valid algorithm
+      }
+    }
+    if (!validAlg) {    // if input is invalid...
+      System.out.println("Sorry, that is not a valid \"Unique\" algorithm.");
+      return;    // exit main method
+    }
 
     switch (exp.name) {
       case "unique1":

--- a/src/edu/allegheny/expose/examples/unique/UniqueExperiment.java
+++ b/src/edu/allegheny/expose/examples/unique/UniqueExperiment.java
@@ -12,7 +12,6 @@ public class UniqueExperiment extends DoublingExperiment {
   protected int alg;
   protected String name;
   private int[] n;
-  private static boolean validAlg;    // to check validity of algorithm name input
 
   public static String[] algs = {"unique1", "unique2"};
 
@@ -27,7 +26,7 @@ public class UniqueExperiment extends DoublingExperiment {
     UniqueExperiment exp = new UniqueExperiment(nargs);
     exp.name = args[0];
 
-    validAlg = false;    // input assumed to be invalid algorithm
+    boolean validAlg = false;    // input assumed to be invalid algorithm
     for (int i = 0; i < algs.length; i++) {    // for each valid algorithm option...
       if (algs[i].equals(exp.name)) {    // check if input equals valid algorithm option
         validAlg = true;    // true when input matches at least one valid algorithm
@@ -35,6 +34,7 @@ public class UniqueExperiment extends DoublingExperiment {
     }
     if (!validAlg) {    // if input is invalid...
       System.out.println("Sorry, that is not a valid \"Unique\" algorithm.");
+      System.out.println("Supported algorithms are: " + Arrays.toString(algs));
       return;    // exit main method
     }
 


### PR DESCRIPTION
- Fixed the spelling of "QUADRADIC" to "QUADRATIC" across all project files. The output should now read: "... algorithm is QUADRATIC".
- Added checking to see if inputted algorithm name matches valid algorithm options. For example, before you could run `$ java edu.allegheny.expose.examples.unique.UniqueExperiment bubble --verbose` and it would still run the experiment, though for which algorithm I'm not sure. Now, if you run `$ java edu.allegheny.expose.examples.unique.UniqueExperiment bubble --verbose`, you get the following message: `$ Sorry, that is not a valid "Unique" algorithm.`
  This checking was implemented in main methods of SortingExperiment.java and UniqueExperiment.java. It may be good to update the README so that other extensions of the DoubleExperiment class may also include this checking.
